### PR TITLE
Rework of modules chapter + compact term encoding for BEAM code chunk

### DIFF
--- a/chapters/beam_modules.asciidoc
+++ b/chapters/beam_modules.asciidoc
@@ -134,7 +134,7 @@ ExportChunk = <<
 
 ----
 
-+FunctionName+ is the index in the atom table.
+`FunctionName` is the index in the atom table.
 
 We can extend our parse_chunk function by adding the following clause after the atom handling clause: 
 
@@ -486,7 +486,7 @@ TODO
 
 [[SEC-BeamModulesCTE]]
 
-=== Compact Term Encoding
+==== Compact Term Encoding
 
 Let's look at the algorithm, used by `beam_asm:encode`. BEAM files use a special encoding to store simple terms in BEAM file in a space-efficient way. It is different from memory term layout, used by the VM.
 
@@ -551,7 +551,7 @@ If the following value is greater than 8 bytes, then all bits 3-4-5-6-7 will be 
 1 1 1 1 1 | Tag    ||  (Size-9)               ||
 ----
 
-==== Tag Types
+===== Tag Types
 
 When reading compact term format, the resulting integer may be interpreted differently based on what is the value of `Tag`.
 

--- a/chapters/beam_modules.asciidoc
+++ b/chapters/beam_modules.asciidoc
@@ -87,7 +87,7 @@ Here we can see the chunk names that beam uses.
 
 ==== Atom table chunk
 
-The chunk named +Atom+ is mandatory and contains all atoms referred to by the module. The format of the atom chunk (omitting its mandatory chunk header and the padding) is:
+The chunk named `Atom` is mandatory and contains all atoms referred to by the module. The format of the atom chunk is:
 
 [source,erlang]
 ----
@@ -115,9 +115,9 @@ include::../code/beam_modules_chapter/src/beamfile2.erl[]
 
 ==== Export table chunk
 
-The chunk named +ExpT+ (for EXPort Table) is mandatory and contains information about which functions are exported.
+The chunk named `ExpT` (for EXPort Table) is mandatory and contains information about which functions are exported.
 
-The format of the chunk (omitting its mandatory chunk header and the padding) is:
+The format of the export chunk is:
 
 [source,erlang]
 ----
@@ -161,52 +161,75 @@ parse_exports(<<>>) -> [].
 
 ==== Import table chunk
 
-The chunk named &ldquo;ImpT&rdquo; (for IMPort Table) is mandatory and contains information about which functions are imported.
+The chunk named `ImpT` (for IMPort Table) is mandatory and contains information about which functions are imported.
 
 The format of the chunk is: 
 
+[source,erlang]
 ----
-{“ImpT”:4
-  CHUNKSIZE:4
-  NUMBEROFENTRIES:4
-  [{FUNCTION:4,
-    ARITY:4,
-    LABEL:4
-   }]:NUMBEROFENTRIES
-}
+ImportChunk = <<
+  ChunkName:4/unit:8 = "ImpT",
+  ChunkSize:32/big,
+  ImportCount:32/big,
+  [ << ModuleName:32/big,
+       FunctionName:32/big,
+       Arity:32/big
+    >> || repeat ImportCount ],
+  Padding4:0..3/unit:8
+>>
 
 ----
 
+Here `ModuleName` and `FunctionName` are indexes in the atom table.
 
-
-The code for parsing the import table is basically the same as that for parsing the export table, and we can actually use the same function to parse entries in both tables. See the full code at the end of the chapter.
+NOTE: The code for parsing the import table is similar to that which parses the export table, but not exactly: both are triplets of 32-bit integers, just their meaning is different. See the full code at the end of the chapter.
 
 [[code_chunk]]
 
 ==== Code Chunk
 
-The chunk named &ldquo;Code&rdquo; contains the beam code for the module and is mandatory. The format of the chunk is: 
+The chunk named `Code` contains the beam code for the module and is mandatory. The format of the chunk is:
+
+[source,erlang]
+----
+ImportChunk = <<
+  ChunkName:4/unit:8 = "Code",
+  ChunkSize:32/big,
+  SubSize:32/big,
+  InstructionSet:32/big,        % Must match code version in the emulator
+  OpcodeMax:32/big,
+  LabelCount:32/big,
+  FunctionCount:32/big,
+  Code:(ChunkSize-SubSize)/binary,  % all remaining data
+  Padding4:0..3/unit:8
+>>
 
 ----
-{“Code”:4
-  CHUNKSIZE:4
-  SUBSIZE:4
-  INSTRUCTIONSET:4
-  OPCODEMAX:4
-  NUMBEROFLABELS:4
-  NUMBEROFFUNCTIONS:4
-  [OPCODE:1]:(CHUNKSIZE-SUBSIZE)
-  [4-BYTEPAD:1]:0..3
-}
+
+
+The field `SubSize` stores the number of words before the code starts. This makes it possible to add new information fields in the code chunk without breaking older loaders.
+
+The `InstructionSet` field indicates which version of the instruction set the file uses. The version number is increased if any instruction is changed in an incompatible way.
+
+The `OpcodeMax` field indicates the highest number of any opcode used in the code. New instructions can be added to the system in a way such that older loaders still can load a newer file as long as the instructions used in the file are within the range the loader knows about.
+
+The field `LabelCount` contains the number of labels so that a loader can preallocate a label table of the right size in one call. The field `FunctionCount` contains the number of functions so that the functions table could also be preallocated efficiently.
+
+The `Code` field contains instructions, chained together, where each instruction has the following format:
+
+[source,erlang]
+----
+Instruction = <<
+  InstructionCode:8,
+  [beam_asm:encode(Argument) || repeat Arity]
+>>
 ----
 
+Here `Arity` is hardcoded in the table, which is generated from ops.tab by genop script when the emulator is built from source.
 
+The encoding produced by `beam_asm:encode` is explained below in the  <<SEC-BeamModulesCTE,Compact Term Encoding>> section.
 
-The field SUBSIZE stores the number of words before the code starts. This makes it possible to add new information fields in the code chunk without breaking older loaders. The INSTRUCTIONSET field indicates which version of the instruction set the file uses. The version number is increased if any instruction is changed in an incompatible way.
-
-The OPCODEMAX field indicates the highest number of any opcode used in the code. New instructions can be added to the system in a way such that older loaders still can load a newer file as long as the instructions used in the file are within the range the loader knows about.
-
-The field NUMBEROFLABELS contains the number of labels so that a loader can preallocate a label table of the right size. The field NUMBEROFFUNCTIONS contains the number of functions so that a loader can preallocate a functions table of the right size.
+===== Parsing the CODE Chunk
 
 We can parse out the code chunk by adding the following code to our program: 
 
@@ -428,3 +451,85 @@ This chunk type is now obsolete.
 ==== Bringing it all Together
 
 TODO
+
+
+[[SEC-BeamModulesCTE]]
+
+=== Compact Term Encoding
+
+Let's look at the algorithm, used by `beam_asm:encode`. BEAM files use a special encoding to store simple terms in BEAM file in a space-efficient way. It is different from memory term layout, used by the VM.
+
+TIP: `Beam_asm` is a module in the `compiler` application, part of the Erlang distribution, it is used to assemble binary content of beam modules.
+
+The reason behind this complicated design is to try and fit as many type and value data into the first byte as possible to make code section more compact. After decoding all encoded values become full size machine words or terms.
+
+[shaape]
+----
+7 6 5 4 3 | 2 1 0
+----------+-------+
+          | 0 0 0 | Literal
+          | 0 0 1 | Integer
+          | 0 1 0 | Atom
+          | 0 1 1 | X Register
+          | 1 0 0 | Y Register
+          | 1 0 1 | Label
+          | 1 1 0 | Character
+0 0 0 1 0 | 1 1 1 | Extended - Float
+0 0 1 0 0 | 1 1 1 | Extended - List
+0 0 1 1 0 | 1 1 1 | Extended - Floating point register
+0 1 0 0 0 | 1 1 1 | Extended - Allocation list
+0 1 0 1 0 | 1 1 1 | Extended - Literal
+
+----
+
+It uses first 3 bits of a first byte as a tag to specify the type of the following value. If the bits were all 1 (special value 7), then few more bits are used.
+
+For values under 16 the value is placed entirely into bits 4-5-6-7 having bit 3 set to 0:
+
+[shaape]
+----
+7 6 5 4 | 3 | 2 1 0
+--------+---+------
+Value   | 0 | Tag
+----
+
+For values under 16#800 (2048) bit 3 is set to 1, marks that 1 continuation byte will be used and 3 most significant bits of the value will extend into this byte’s bits 5-6-7:
+
+[shaape]
+----
+7 6 5 | 4 3 | 2 1 0
+------+-----+------
+Value | 0 1 | Tag
+----
+
+Larger and negative values are first converted to bytes. Then if the value takes 2..8 bytes, bits 3-4 will be set to 1, and bits 5-6-7 will contain the (Bytes-2) size for the value, which follows:
+
+[shaape]
+----
+7  6  5 | 4 3 | 2 1 0
+--------+-----+------
+Bytes-2 | 1 1 | Tag
+----
+
+If the following value is greater than 8 bytes, then all bits 3-4-5-6-7 will be set to 1, followed by a nested encoded unsigned `?tag_u` value of (Bytes-9):8, and then the data:
+
+[shaape]
+----
+7 6 5 4 3 | 2 1 0  ||  Followed by a          ||
+----------+------  ||  nested encoded literal || Data . . .
+1 1 1 1 1 | Tag    ||  (Size-9)               ||
+----
+
+==== Tag Types
+
+When reading compact term format, the resulting integer may be interpreted differently based on what is the value of `Tag`.
+
+* For literals the value is index into the literal table.
+* For atoms, the value is atom index MINUS one. If the value is 0, it means `NIL` (empty list) instead.
+* For labels 0 means invalid value.
+* If tag is character, the value is unsigned unicode codepoint.
+* Tag Extended List contains pairs of terms. Read `Size`, create tuple of `Size` and then read `Size/2` pairs into it. Each pair is `Value` and `Label`. `Value` is a term to compare against and `Label` is where to jump on match. This is used in `select_val` instruction.
+
+
+
+Refer to `beam_asm:encode/2` in the compiler application for details about how this is encoded. Tag values are presented in this section, but also can be found in `compiler/src/beam_opcodes.hrl`.

--- a/chapters/beam_modules.asciidoc
+++ b/chapters/beam_modules.asciidoc
@@ -87,25 +87,24 @@ Here we can see the chunk names that beam uses.
 
 ==== Atom table chunk
 
-The chunk named Atom is mandatory and contains all atoms referred to by the module. The format of the atom chunk is: 
+The chunk named +Atom+ is mandatory and contains all atoms referred to by the module. The format of the atom chunk (omitting its mandatory chunk header and the padding) is:
+
+[source,erlang]
+----
+AtomChunk = <<
+  ChunkName:4/unit:8 = "Atom",
+  ChunkSize:32/big,
+  NumberOfAtoms:32/big,
+  [<<AtomLength:8, AtomName:AtomLength/unit:8>> || repeat NumberOfAtoms],
+  Padding4:0..3/unit:8
+>>
 
 ----
-{“Atom”:4
-  CHUNKSIZE:4
-  NUMBEROFATOMS:4
-  [{LENGTH:1,
-    ATOM:LENGTH}]:NUMBEROFATOMS
-  [4-BYTEPAD:1]:0..3
-}
-
-----
 
 
-
-_NOTE:_ There is a further constraint that the module name must be stored as the first atom in the table.
+NOTE: Module name is always stored as the first atom in the table (atom index 0).
 
 Let us add a decoder for the atom chunk to our Beam file reader:
-
 
 [source,erlang]
 ----
@@ -116,23 +115,26 @@ include::../code/beam_modules_chapter/src/beamfile2.erl[]
 
 ==== Export table chunk
 
-The chunk named &ldquo;ExpT&rdquo; (for EXPort Table) is mandatory and contains information about which functions are exported.
+The chunk named +ExpT+ (for EXPort Table) is mandatory and contains information about which functions are exported.
 
-The format of the chunk is: 
+The format of the chunk (omitting its mandatory chunk header and the padding) is:
+
+[source,erlang]
+----
+ExportChunk = <<
+  ChunkName:4/unit:8 = "ExpT",
+  ChunkSize:32/big,
+  ExportCount:32/big,
+  [ << FunctionName:32/big,
+       Arity:32/big,
+       Label:32/big
+    >> || repeat ExportCount ],
+  Padding4:0..3/unit:8
+>>
 
 ----
-{“ExpT”:4
-  CHUNKSIZE:4
-  NUMBEROFENTRIES:4
-  [{FUNCTION:4,
-    ARITY:4,
-    LABEL:4
-   }]:NUMBEROFENTRIES
-}
 
-----
-
-
++FunctionName+ is the index in the atom table.
 
 We can extend our parse_chunk function by adding the following clause after the atom handling clause: 
 

--- a/chapters/beam_modules.asciidoc
+++ b/chapters/beam_modules.asciidoc
@@ -6,7 +6,8 @@
 
 === Modules
 
-What is a module. How is code loaded. How does hot code loading work. How does the purging work. How does the code server work. How does dynamic code loading work, the code search path. Handling code in a distributed system. (Overlap with chapter 10, have to see what goes where.) Parameterized modules. How p-mods are implemented. The trick with p-mod calls. Here follows an excerpt from the current draft:
+.%% TODO
+NOTE: What is a module. How is code loaded. How does hot code loading work. How does the purging work. How does the code server work. How does dynamic code loading work, the code search path. Handling code in a distributed system. (Overlap with chapter 10, have to see what goes where.) Parameterized modules. How p-mods are implemented. The trick with p-mod calls. Here follows an excerpt from the current draft:
 
 [[BEAM_files]]
 
@@ -16,38 +17,32 @@ The definite source of information about the beam file format is obviously the s
 
 The beam file format is based on the interchange file format (EA IFF)#, with two small changes. We will get to those shortly. An IFF file starts with a header followed by a number of &ldquo;chunks&rdquo;. There are a number of standard chunk types in the IFF specification dealing mainly with images and music. But the IFF standard also lets you specify your own named chunks, and this is what BEAM does.
 
-An IFF file looks like this:
+NOTE: Beam files differ from standard IFF files, in that each chunk is aligned on 4-byte boundary (i.e. 32 bit word) instead of on a 2-byte boundary as in the IFF standard. To indicate that this is not a standard IFF file the IFF header is tagged with &ldquo;FOR1&rdquo; instead of &ldquo;FORM&rdquo;. The IFF specification suggests this tag for future extensions.
 
+Beam uses form type &ldquo;BEAM&rdquo;. A beam file header has the following layout:
 
+[source,erlang]
 ----
-{‘FORM’:4
- SIZE:4
- FORMTYPE:4
- [{CHUNKNAME:4
-   CHUNKSIZE:4
-   [CHUNKDATA:1]:CHUNKSIZE
-   [2-BYTEPAD:1]:0..1
-  }
- ]:SIZE-4
-}
+BEAMHeader = <<
+  IffHeader:4/unit:8 = "FOR1",
+  Size:32/big,                  // big endian, how many more bytes are there
+  FormType:4/unit:8 = "BEAM"
+>>
 
 ----
 
-Beam files differ from standard IFF files, in that each chunk is aligned on 4-byte boundary (i.e. 32 bit word) instead of on a 2-byte boundary as in the IFF standard. To indicate that this is not a standard IFF file the IFF header is tagged with &ldquo;FOR1&rdquo; instead of &ldquo;FORM&rdquo;. The IFF specification suggest this tag for future extensions.
+After the header multiple chunks can be found. Size of each chunk is aligned to the multiple of 4 and each chunk has its own header (below).
 
-The form type used by beam is &ldquo;BEAM&rdquo;. A beam file has the following layout: 
+NOTE: The alignment is important for some platforms, where unaligned memory byte access would create a hardware exception (named SIGBUS in Linux). This can turn out to be a performance hit or the exception could crash the VM.
 
+[source,erlang]
 ----
-{‘FOR1’:4
- SIZE:4
- ‘BEAM’:4
- [{CHUNKNAME:4
-  CHUNKSIZE:4
-  [CHUNKDATA:1]:CHUNKSIZE
-  [4-BYTEPAD:1]:0..3
-  }
- ]:SIZE-4
-}
+BEAMChunk = <<
+  ChunkName:4/unit:8,           // "Code", "Atom", "StrT", "LitT", ...
+  ChunkSize:32/big,
+  ChunkData:ChunkSize/unit:8,   // data format is defined by ChunkName
+  Padding4:0..3/unit:8
+>>
 
 ----
 

--- a/chapters/beam_modules.asciidoc
+++ b/chapters/beam_modules.asciidoc
@@ -138,6 +138,7 @@ ExportChunk = <<
 
 We can extend our parse_chunk function by adding the following clause after the atom handling clause: 
 
+[source,erlang]
 ----
 parse_chunks([{"ExpT", _Size,
              <<_Numberofentries:32/integer, Exports/binary>>}
@@ -229,10 +230,9 @@ Here `Arity` is hardcoded in the table, which is generated from ops.tab by genop
 
 The encoding produced by `beam_asm:encode` is explained below in the  <<SEC-BeamModulesCTE,Compact Term Encoding>> section.
 
-===== Parsing the CODE Chunk
+We can parse out the code chunk by adding the following code to our program:
 
-We can parse out the code chunk by adding the following code to our program: 
-
+[source,erlang]
 ----
 parse_chunks([{"Code", Size, <<SubSize:32/integer,Chunk/binary>>           
               } | Rest], Acc) ->
@@ -268,16 +268,19 @@ We will learn how to decode the beam instructions in a later chapter, aptly name
 
 ==== String table chunk
 
-The chunk named &ldquo;StrT&rdquo; is mandatory and contains all constant string literals in the module as one long string. If there are no string literals the chunks should still be present but empty and of size 0.
+The chunk named `StrT` is mandatory and contains all constant string literals in the module as one long string. If there are no string literals the chunks should still be present but empty and of size 0.
 
 The format of the chunk is:
 
+[source,erlang]
 ----
-{“StrT”:4
- CHUNKSIZE:4
- [STRINGBYTE]:CHUNKSIZE
- [4-BYTEPAD:1]:0..3
-}
+StringChunk = <<
+  ChunkName:4/unit:8 = "StrT",
+  ChunkSize:32/big,
+  Data:ChunkSize/binary,
+  Padding4:0..3/unit:8
+>>
+
 ----
 
 The string chunk can be parsed easily by just turning the string of bytes into a binary:
@@ -290,22 +293,27 @@ parse_chunks([{"StrT", _Size, <<Strings/binary>>} | Rest], Acc) ->
 
 ==== Attributes Chunk
 
-The chunk named "Attr" is optional, but some OTP tools expect the attributes to be present. The releashandler expect the "vsn" attribute to be present. You can get the version attribute from a file with: beam_lib:version(Filename), this function assumes that there is an attribute chunk with a "vsn" attribute present.
+The chunk named `Attr` is optional, but some OTP tools expect the attributes to be present. The releashandler expect the "vsn" attribute to be present. You can get the version attribute from a file with: beam_lib:version(Filename), this function assumes that there is an attribute chunk with a "vsn" attribute present.
 
 The format of the chunk is:
 
 
+[source,erlang]
 ----
-{"Attr":4
-  CHUNKSIZE:4
-  ATTRIBUTES:CHUNKSIZE
-  [4-BYTEPAD]:0..3
-}
+AttributesChunk = <<
+  ChunkName:4/unit:8 = "Attr",
+  ChunkSize:32/big,
+  Attributes:ChunkSize/binary,
+  Padding4:0..3/unit:8
+>>
+
 ----
+
 
 We can parse the attribute chunk like this:
 
 
+[source,erlang]
 ----
 parse_chunks([{"Attr", Size, Chunk} | Rest], Acc) ->
     <<Bin:Size/binary, _Pad/binary>> = Chunk,
@@ -316,22 +324,26 @@ parse_chunks([{"Attr", Size, Chunk} | Rest], Acc) ->
 
 ==== Compilation Information Chunk
 
-The chunk named "CInf" is optional, but some OTP tools expect the information to be present. 
+The chunk named `CInf` is optional, but some OTP tools expect the information to be present.
 
 The format of the chunk is:
 
 
+[source,erlang]
 ----
-{"CInf":4
-  CHUNKSIZE:4
-  INFORMATION:CHUNKSIZE
-  [4-BYTEPAD]:0..3
-}
+CompilationInfoChunk = <<
+  ChunkName:4/unit:8 = "CInf",
+  ChunkSize:32/big,
+  Data:ChunkSize/binary,
+  Padding4:0..3/unit:8
+>>
+
 ----
 
 We can parse the compilation information chunk like this:
 
 
+[source,erlang]
 ----
 parse_chunks([{"CInf", Size, Chunk} | Rest], Acc) ->
     <<Bin:Size/binary, _Pad/binary>> = Chunk,
@@ -342,46 +354,60 @@ parse_chunks([{"CInf", Size, Chunk} | Rest], Acc) ->
 
 ==== Local Function Table Chunk
 
-The chunk named "LocT" is optional and intended for cross reference tools. 
+The chunk named `LocT` is optional and intended for cross reference tools.
 
 The format is the same as that of the export table:
 
 
+[source,erlang]
 ----
-{"LocT":4
-  CHUNKSIZE:4
-  NUMBEROFENTRIES:4
-  [{FUNCTION:4,
-    ARITY:4,
-    LABEL:4
-   }]:NUMBEROFENTRIES
-}
+LocalFunTableChunk = <<
+  ChunkName:4/unit:8 = "LocT",
+  ChunkSize:32/big,
+  FunctionCount:32/big,
+  [ << FunctionName:32/big,
+       Arity:32/big,
+       Label:32/big
+    >> || repeat FunctionCount ],
+  Padding4:0..3/unit:8
+>>
+
 ----
 
-The code for parsing the local function table is basically the same as that for parsing the export and the import table, and we can actually use the same function to parse entries in all tables. See the full code at the end of the chapter.
+NOTE: The code for parsing the local function table is basically the same as that for parsing the export and the import table, and we can actually use the same function to parse entries in all tables. See the full code at the end of the chapter.
 
 
 ==== Literal Table Chunk
 
-The chunk named "LitT" is optional and contains compressed code literals. The format of the chunk is:
+The chunk named `LitT` is optional and contains all literal values from the module source in compressed form, which are not immediate values. The format of the chunk is:
 
+
+[source,erlang]
+----
+LiteralTableChunk = <<
+  ChunkName:4/unit:8 = "LitT",
+  ChunkSize:32/big,
+  UncompressedSize:32/big,      % It is nice to know the size to allocate some memory
+  CompressedLiterals:ChunkSize/binary,
+  Padding4:0..3/unit:8
+>>
 
 ----
-{"LitT":4
-  CHUNKSIZE:4
-  COMPRESSEDTABLESIZE:4
-  <NUMBEROFLITERALS:4,
-    [{SIZE:4
-      LITERAL:SIZE
-     }]:NUMBEROFLITERALS
-   }>:COMPRESSEDTABLESIZE
-}
+
+Where the `CompressedLiterals` must have exactly `UncompressedSize` bytes. Each literal in the table is encoded with the External Term Format (`erlang:term_to_binary`). The format of `CompressedLiterals` is the following:
+
+----
+CompressedLiterals = <<
+  Count:32/big,
+  [ <<Size:32/big, Literal:binary>>  || repeat Count ]
+>>
 ----
 
-The whole table is compressed with zlib:compress/1, and can be uncompressed with zlib_uncompress/1.
+The whole table is compressed with `zlib:compress/1` (deflate algorithm), and can be uncompressed with `zlib:uncompress/1` (inflate algorithm).
 
-We can parse the chunk like this
+We can parse the chunk like this:
 
+[source,erlang]
 ----
 parse_chunks([{"LitT", _ChunkSize,
               <<_CompressedTableSize:32, Compressed/binary>>}
@@ -394,6 +420,8 @@ parse_chunks([{"LitT", _ChunkSize,
 
 
 ...
+
+[source,erlang]
 ----
 parse_literals(<<Size:32,Literal:Size/binary,Tail/binary>>) ->
     [binary_to_term(Literal) | parse_literals(Tail)];
@@ -407,19 +435,22 @@ parse_literals(<<>>) -> [].
 
 ==== Abstract Code Chunk
 
-The chunk named "Abst" is optional and may contain the code in abstract form. If you give the flag debug_info to the compiler it will store the abstract syntax tree for the module in this chunk. OTP tools like the debugger and Xref need the abstract form. The format of the chunk is:
+The chunk named `Abst` is optional and may contain the code in abstract form. If you give the flag `debug_info` to the compiler it will store the abstract syntax tree for the module in this chunk. OTP tools like the debugger and Xref need the abstract form. The format of the chunk is:
 
-
+[source,erlang]
 ----
-{"Abst":4
-  CHUNKSIZE:4
-  [ABSTRACTCODE]:CHUNKSIZE
-  [4-BYTEPAD:1]:0..3
-}
+AbstractCodeChunk = <<
+  ChunkName:4/unit:8 = "Abst",
+  ChunkSize:32/big,
+  AbstractCode:ChunkSize/binary,
+  Padding4:0..3/unit:8
+>>
+
 ----
 
 We can parse the chunk like this
 
+[source,erlang]
 ----
 parse_chunks([{"Abst", _ChunkSize, <<>>} | Rest], Acc) ->
     parse_chunks(Rest,Acc);

--- a/chapters/beam_modules.asciidoc
+++ b/chapters/beam_modules.asciidoc
@@ -492,19 +492,19 @@ Let's look at the algorithm, used by `beam_asm:encode`. BEAM files use a special
 
 TIP: `Beam_asm` is a module in the `compiler` application, part of the Erlang distribution, it is used to assemble binary content of beam modules.
 
-The reason behind this complicated design is to try and fit as many type and value data into the first byte as possible to make code section more compact. After decoding all encoded values become full size machine words or terms.
+The reason behind this complicated design is to try and fit as much type and value data into the first byte as possible to make code section more compact. After decoding all encoded values become full size machine words or terms.
 
 [shaape]
 ----
 7 6 5 4 3 | 2 1 0
 ----------+-------+
-          | 0 0 0 | Literal
-          | 0 0 1 | Integer
-          | 0 1 0 | Atom
-          | 0 1 1 | X Register
-          | 1 0 0 | Y Register
-          | 1 0 1 | Label
-          | 1 1 0 | Character
+          | 0 0 0 | Literal         (tag_u in beam_opcodes.hrl)
+          | 0 0 1 | Integer         (tag_i)
+          | 0 1 0 | Atom            (tag_a)
+          | 0 1 1 | X Register      (tag_x)
+          | 1 0 0 | Y Register      (tag_y)
+          | 1 0 1 | Label           (tag_f)
+          | 1 1 0 | Character       (tag_h)
 0 0 0 1 0 | 1 1 1 | Extended - Float
 0 0 1 0 0 | 1 1 1 | Extended - List
 0 0 1 1 0 | 1 1 1 | Extended - Floating point register
@@ -513,9 +513,9 @@ The reason behind this complicated design is to try and fit as many type and val
 
 ----
 
-It uses first 3 bits of a first byte as a tag to specify the type of the following value. If the bits were all 1 (special value 7), then few more bits are used.
+It uses first 3 bits of a first byte to store the tag which defines the type of the following value. If the bits were all 1 (special value 7 or ?tag_z from `beam_opcodes.hrl`), then few more bits are used.
 
-For values under 16 the value is placed entirely into bits 4-5-6-7 having bit 3 set to 0:
+For values under 16, the value is placed entirely into bits 4-5-6-7 having bit 3 set to 0:
 
 [shaape]
 ----
@@ -524,7 +524,7 @@ For values under 16 the value is placed entirely into bits 4-5-6-7 having bit 3 
 Value   | 0 | Tag
 ----
 
-For values under 16#800 (2048) bit 3 is set to 1, marks that 1 continuation byte will be used and 3 most significant bits of the value will extend into this byte’s bits 5-6-7:
+For values under 2048 (16#800) bit 3 is set to 1, marks that 1 continuation byte will be used and 3 most significant bits of the value will extend into this byte’s bits 5-6-7:
 
 [shaape]
 ----
@@ -542,7 +542,7 @@ Larger and negative values are first converted to bytes. Then if the value takes
 Bytes-2 | 1 1 | Tag
 ----
 
-If the following value is greater than 8 bytes, then all bits 3-4-5-6-7 will be set to 1, followed by a nested encoded unsigned `?tag_u` value of (Bytes-9):8, and then the data:
+If the following value is greater than 8 bytes, then all bits 3-4-5-6-7 will be set to 1, followed by a nested encoded unsigned literal (macro `?tag_u` in `beam_opcodes.hrl`) value of (Bytes-9):8, and then the data:
 
 [shaape]
 ----


### PR DESCRIPTION
* Reviewed and updated BEAM file format in the modules chapter.
* Rewrote fields of the BEAM sections in more Erlang-friendly pseudo-binary syntax with bits and endianness. Not a valid Erlang syntax, but I hope is readable for an Erlang person.
* Added Compact Term Encoding section (end of chapter, heading levels 4 and 5)