### PR TITLE
Typos

### DIFF
--- a/chapters/processes.asciidoc
+++ b/chapters/processes.asciidoc
@@ -218,7 +218,7 @@ and more information about a process with
  <0.41.0>,<0.42.0>,<0.44.0>,<0.45.0>,<0.46.0>,<0.47.0>,
  <0.48.0>,<0.49.0>,<0.50.0>,<0.51.0>,<0.52.0>,<0.53.0>,
  <0.54.0>,<0.60.0>]
-2> CodeServerPid = whereis(codeserver).
+2> CodeServerPid = whereis(code_server).
 <0.36.0>
 3> erlang:process_info(CodeServerPid).
 [{registered_name,code_server},

--- a/chapters/processes.asciidoc
+++ b/chapters/processes.asciidoc
@@ -355,7 +355,7 @@ image::../images/observer_system.png[]
 We will go over some of this information in detail later in
 this and the next chapter. For now we will just use the Observer to look
 at the running processes. First we take a look at the
-`Application` tab which shows the supervision
+`Applications` tab which shows the supervision
 tree of the running system:
 
 image::../images/observer_applications.png[]


### PR DESCRIPTION
Typos:
 - the code server is registered as `code_server` not `codeserver`
 - `Applications` tab rather than `Application` tab in the observer