### PR TITLE
Fix a bunch of "lable" typos

### DIFF
--- a/chapters/compiler.asciidoc
+++ b/chapters/compiler.asciidoc
@@ -299,8 +299,8 @@ Then comes a list of exports and any compiler attributes (none in this
 example) much like in any Erlang source module.
 
 The first real beam-like instruction is +{labels, 7}+ which tells the
-VM the number of lables in the code to make it possible to allocate 
-room for all lables in one pass over the code.
+VM the number of labels in the code to make it possible to allocate 
+room for all labels in one pass over the code.
 
 After that there is the actual code for each function. The first
 instruction gives us the function name, the arity and the entry point
@@ -547,7 +547,7 @@ json_code([])                     -> [];
 json_code([?JSON(Json)|MoreCode]) -> [parse_json(Json) | json_code(MoreCode)];
 json_code(Code)                   -> Code.
 
-%% Json Object -> [{}] | [{Lable, Term}]
+%% Json Object -> [{}] | [{Label, Term}]
 parse_json({tuple,Line,[]})            -> {cons, Line, {tuple, Line, []}};
 parse_json({tuple,Line,Fields})        -> parse_json_fields(Fields,Line);
 %% Json Array -> List
@@ -573,11 +573,11 @@ parse_json({op, Line, '-', {Type, _, N}}) when Type =:= integer
                                           {Type, Line, -N}.
 %% parse_json(Code)                  -> io:format("Code: ~p~n",[Code]), Code.
 
--define(FIELD(Lable, Code), {remote, L, {string, _, Label}, Code}).
+-define(FIELD(Label, Code), {remote, L, {string, _, Label}, Code}).
 
 parse_json_fields([], L) -> {nil, L};
 %% Label : Json-Term  --> [{<<Label>>, Term} | Rest]
-parse_json_fields([?FIELD(Lable, Code) | Rest], _) ->
+parse_json_fields([?FIELD(Label, Code) | Rest], _) ->
     cons(tuple(str_to_bin(Label, L), parse_json(Code), L)
          , parse_json_fields(Rest, L)
          , L).

--- a/code/compiler_chapter/src/json_parser.erl
+++ b/code/compiler_chapter/src/json_parser.erl
@@ -29,7 +29,7 @@ json_code([])                     -> [];
 json_code([?JSON(Json)|MoreCode]) -> [parse_json(Json) | json_code(MoreCode)];
 json_code(Code)                   -> Code.
 
-%% Json Object -> [{}] | [{Lable, Term}]
+%% Json Object -> [{}] | [{Label, Term}]
 parse_json({tuple,Line,[]})            -> {cons, Line, {tuple, Line, []}};
 parse_json({tuple,Line,Fields})        -> parse_json_fields(Fields,Line);
 %% Json Array -> List
@@ -55,11 +55,11 @@ parse_json({op, Line, '-', {Type, _, N}}) when Type =:= integer
                                           {Type, Line, -N}.
 %% parse_json(Code)                  -> io:format("Code: ~p~n",[Code]), Code.
 
--define(FIELD(Lable, Code), {remote, L, {string, _, Label}, Code}).
+-define(FIELD(Label, Code), {remote, L, {string, _, Label}, Code}).
 
 parse_json_fields([], L) -> {nil, L};
 %% Label : Json-Term  --> [{<<Label>>, Term} | Rest]
-parse_json_fields([?FIELD(Lable, Code) | Rest], _) ->
+parse_json_fields([?FIELD(Label, Code) | Rest], _) ->
     cons(tuple(str_to_bin(Label, L), parse_json(Code), L)
          , parse_json_fields(Rest, L)
          , L).


### PR DESCRIPTION
Taking advantage of this PR to ask what may be a silly question: is there any way we could standardize on LF in the `.asciidoc` files? They appear to be using CRs right now, or maybe I am missing something 😕 

(PS: thanks for this book!)