### PR TITLE
Add default attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ beam-book.pdf: xml/beam-book-from-ab.xml
 	dblatex $(DBLATEX_OPTS) xml/beam-book-from-ab.xml -o $@
 
 index.html:
-	asciidoctor -r asciidoctor-diagram --backend=html5 --doctype=book -a icons=font -a toc2 -o site/index.html book.asciidoc
+	asciidoctor -r asciidoctor-diagram --backend=html5 --doctype=book -o site/index.html book.asciidoc
 
 code/book/ebin/generate_op_doc.beam: code/book/src/generate_op_doc.erl
 	erlc -o $(dir $@) $<

--- a/book.asciidoc
+++ b/book.asciidoc
@@ -1,4 +1,11 @@
 = The Erlang Runtime System
+:author: Erik Stenman
+:encoding: utf-8
+:lang: en
+:toc: left
+:toclevels: 3
+:experimental:
+:icons: font
 
 include::chapters/preface.asciidoc[]
 


### PR DESCRIPTION
Added some default attributes to book.asciidoc and also moved some
attributes from the command line in Makefile. I think this is better as
we may add more and more attributes in the future.

Added:
- author
- encoding
- lang
- experimental

Moved/Modified:
- toc2 -> toc
- icons