### PR TITLE
Add missing erlang to execute erl command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - docker pull asciidoctor/docker-asciidoctor:latest
 
 script:
-  - docker run -i -v ${PWD}:/documents/ -t --name thebeambook asciidoctor/docker-asciidoctor bash -c "apk add --no-cache git rsync && make"
+  - docker run -i -v ${PWD}:/documents/ -t --name thebeambook asciidoctor/docker-asciidoctor bash -c "apk add --no-cache git rsync erlang && make"
 
 after_error:
   - docker logs thebeambook


### PR DESCRIPTION
I wanted to [debug the Travis error](https://docs.travis-ci.com/user/build-config-validation/), but it seems not activated ? Maybe we could activate it.
> To enable debug for your public repositories, please email us at support@travis-ci.com and let us know which repositories you want activated.

~How about making builds enabled (without deployment, of course) for each PR in the future ?~
Oh it's already doing it :-)