### PR TITLE
Use more descriptive reference style

### DIFF
--- a/book.asciidoc
+++ b/book.asciidoc
@@ -15,7 +15,7 @@
 :ditaa-shadows: false
 :ditaa-transparent: true
 :attribute-missing: warn
-:xrefstyle: full
+:xrefstyle: short
 
 include::chapters/preface.asciidoc[]
 

--- a/book.asciidoc
+++ b/book.asciidoc
@@ -15,6 +15,7 @@
 :ditaa-shadows: false
 :ditaa-transparent: true
 :attribute-missing: warn
+:xrefstyle: full
 
 include::chapters/preface.asciidoc[]
 


### PR DESCRIPTION
Reference:
https://github.com/asciidoctor/asciidoctor.org/blob/master/docs/_includes/xrefstyle.adoc

To me, it looks better to be able to see chapter/appendices, etc. @happi if you prefer other style I can make a change accordingly.

Before:
<img width="591" alt="ref-before" src="https://user-images.githubusercontent.com/366615/81522332-0b2c7480-92ff-11ea-8652-bbf90529937f.png">
After:
<img width="589" alt="ref-after" src="https://user-images.githubusercontent.com/366615/81522344-1a132700-92ff-11ea-9e33-6c1d08e7afc3.png">
