### PR TITLE
fix a ops.tab file location mistake with OTP source

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,2 @@
-github: [happihacking]
+github: [hitdavid]
+Liberapay: [hitdavid]

--- a/chapters/beam_loader.asciidoc
+++ b/chapters/beam_loader.asciidoc
@@ -15,7 +15,7 @@ and translates from the external (generic) format to the internal
 
 The code for the loader can be found in +beam_load.c+ (in
 +erts/emulator/beam+) but most of the logic for the translations are in
-the file +ops.tab+ (in the same directory).
+the file +ops.tab+ (in +erts/emulator/beam/emu+).
 
 The first step of the loader is to parse beam file, basically the same
 work as we did in Erlang in xref:CH-beam_modules[] but written in C.


### PR DESCRIPTION
file ops.tab is in opt:erts/emulator/beam/emu directory