### PR TITLE
Nit fixed link text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ that you have all the needed tools installed.
 
 ### Docker
 
-Docker images with asciidoctor is available here: [dcoker-asciidoctor](https://github.com/asciidoctor/docker-asciidoctor)
+Docker images with asciidoctor is available here: [docker-asciidoctor](https://github.com/asciidoctor/docker-asciidoctor)
 
 ### Linux
 WIP, to be updated


### PR DESCRIPTION
... for asciidoctor-pdf (docker image)

From reading the documentation, thought I offer a quick fix (not important).

In case this helps, glad to have it merged, in case you decide to not include, no hard feelings.

All the best,
Stefan