### PR TITLE
Allow `git shortlog` to work in non-interactive shells

### DIFF
--- a/bin/gitlog.sh
+++ b/bin/gitlog.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git shortlog -s -n | awk '{$1=""}1' | grep -v "Erik Stenman" | grep -v "Your Name" > $1
+git shortlog -s -n HEAD | awk '{$1=""}1' | grep -v "Erik Stenman" | grep -v "Your Name" > $1


### PR DESCRIPTION
As I was packaging this for [nixpkgs](https://github.com/nixos/nixpkgs), I ran across an issue with the `gitlog.sh` script. When `git shortlog` is called from a shell that is non-interactive (stdin is not a terminal), `git shortlog` will only work if a branch is specified ([Reference link](https://stackoverflow.com/a/43042363)). When nixpkgs builds a package, they use a form of bash that is non-interactive, causing an error to occur when trying to read a portion of the `.git` database that does not exist. This PR addresses this issue while not drastically affecting normal use.