### PR TITLE
Update Erjang link

### DIFF
--- a/chapters/introduction.asciidoc
+++ b/chapters/introduction.asciidoc
@@ -470,7 +470,7 @@ the BEAM compiler from the OTP layer to compile Erlang to Ling.
 
 ==== Erjang
 
-Erjang (link:http://www.erjang.org[]) is an Erlang implementation which runs
+Erjang (link:https://github.com/trifork/erjang[]) is an Erlang implementation which runs
 on the JVM. It loads +.beam+ files and recompiles the code to Java +.class+
 files. Erjang is almost 100% binary compatible with (generic) BEAM.
 


### PR DESCRIPTION
The link to the Erjang homepage now resolves to a Japanese voice acting website. I've updated the link to point readers to the author's GitHub page, which seems to be the most up-to-date resource.