### PR TITLE
fix beam_instructions code example

### DIFF
--- a/chapters/beam_instructions.asciidoc
+++ b/chapters/beam_instructions.asciidoc
@@ -319,8 +319,6 @@ A minimal receive loop, which accepts any message and has no timeout
 
 [source,erlang]
 ----
-  {label,2}.
-    {wait,{f,1}}.
   {label,1}.
     {loop_rec,{f,2},{x,0}}.
     remove_message.


### PR DESCRIPTION
Looks like one of the labels were accidentally included twice, so I removed the duplicate.