### PR TITLE
docs: minor fixes and typo

### DIFF
--- a/chapters/beam_instructions.asciidoc
+++ b/chapters/beam_instructions.asciidoc
@@ -101,8 +101,8 @@ Given the file beamexample1.erl:
 id(I) when is_integer(I) -> I.
 ----
 
-When compiled with `erlc -S beamexample.erl` we get the following
-beamexmaple.S file:
+When compiled with `erlc -S beamexample1.erl` we get the following
+beamexmaple1.S file:
 
 [source,erlang]
 ----
@@ -201,7 +201,7 @@ see in the next section there are several different call instructions.
 
 === Calls
 
-As we have seen in xref:CH-Calls[] there are several different types
+As we will see in xref:CH-Calls[], there are several different types
 of calls in Erlang. To distinguish between local and remote calls
 in the instruction set, remote calls have `+_ext+` in their instruction
 names. Local calls just have a label in the code of the module, while

--- a/chapters/beam_loader.asciidoc
+++ b/chapters/beam_loader.asciidoc
@@ -141,7 +141,7 @@ macro in `beam_emu.c` to do the work.
 
 %macro: move_return:: this tells `ops.tab` to generate the code for `move_return`. If there
 is no `%macro` line, the instruction has to be implemented by hand in beam_emu.c. The code
-for the instruction will be places in `beam_hot.h` or `beam_cold.h` depending on if the
+for the instruction will be placed in `beam_hot.h` or `beam_cold.h` depending on if the
 `%hot` or `%cold` directive is active.
 
 MoveReturn:: tells the code generator to that the name of the c-macro in beam_emu.c to use
@@ -330,7 +330,7 @@ compiles to:
 
 The values in the condition are only allowed to be either integers
 or atoms. If the value is of any other type the compiler will not emit a
-`select_val` instruction. The loader uses a couple of hearistics to figure
+`select_val` instruction. The loader uses a couple of heuristics to figure
 out what type algorithm to use when doing the `select_val`.
 
 jump_on_val:: Create a jump table and use the value as the index. This if very

--- a/chapters/scheduling.asciidoc
+++ b/chapters/scheduling.asciidoc
@@ -101,7 +101,7 @@ By using the _Load Charts_ tab in the Observer we can see that all
 four schedulers are fully loaded while the busy processes execute.
 
 ----
-observer:start().
+2> observer:start().
 ok
 3> RunThem(8).
 ----


### PR DESCRIPTION
PR Description:
- Rename `beamexample.erl` to `beamexample1.erl` for consistency.
- In chapter [7.3. Calls](https://blog.stenmans.org/theBeamBook/#_calls) there's a reference to [Chapter 8](https://blog.stenmans.org/theBeamBook/#CH-Calls) as if it has already been covered, even though it comes later.
- Fix minor typos.
-  Add 2> to indicate that `observer:start()` is Erlang shell command.