### PR TITLE
Fix I/O example typos

### DIFF
--- a/chapters/io.asciidoc
+++ b/chapters/io.asciidoc
@@ -504,7 +504,7 @@ Received data: 14
 Received data: 16
 Received data: 18
 Received data: 20
-[timepout,2,4,6,8,10,12,14,16,18]
+[timeout,2,4,6,8,10,12,14,16,18]
 ```
 We see that the first 5 messages are not asyncronous, but the last 5 are. This is because the port is busy and the send operation is blocking. The port is busy because the id of the message is below 14 and the call is to the `bar` function. The port is busy for 5 seconds and then the last 5 messages are sent asyncronously.
 

--- a/code/io_chapter/pg_example/src/busy_port.erl
+++ b/code/io_chapter/pg_example/src/busy_port.erl
@@ -48,7 +48,7 @@ async_receive() ->
     receive
         {busy_port_example, Data} ->
             Data
-    after 2000 -> timepout
+    after 2000 -> timeout
     end.
 
 call_port(Msg) ->

--- a/code/io_chapter/pg_example/src/pg_router.erl
+++ b/code/io_chapter/pg_example/src/pg_router.erl
@@ -13,5 +13,5 @@ stop() ->
 dispatch() ->
     [
         {"/websocket", websocket_handler, []},
-        {"/[...]", cowboy_static, {priv_dir, my_app, "static"}}
+        {"/[...]", cowboy_static, {priv_dir, pg_example, "static"}}
     ].


### PR DESCRIPTION
## Summary
- fix `timeout` atom in busy_port example
- fix cowboy static app name in websocket router
- adjust I/O chapter snippet for timeout output

## Testing
- `git status --short`
