### PR TITLE
Remove formatting typo

### DIFF
--- a/chapters/debugging.asciidoc
+++ b/chapters/debugging.asciidoc
@@ -336,7 +336,7 @@ erl +hms 512
 This ensures that **all new processes** start with a heap of at least **512 words**, reducing the need for frequent heap expansions.
 
 
-`min_bin_vheap_size` (Minimum Binary Virtual Heap Size)**
+`min_bin_vheap_size` (Minimum Binary Virtual Heap Size)
 
 - Controls the **virtual heap size** for reference-counted binaries (binaries > 64 bytes).
 - Helps **optimize memory allocation** for processes dealing with large binary data.


### PR DESCRIPTION
Hi!
I noticed what I think is an error in formatting - maybe some leftover if the heading was supposed be **bold**? Looking at a similar line https://github.com/happi/theBeamBook/blame/master/chapters/debugging.asciidoc#L321, it seems it's not supposed to be bold, so I removed the asterisks.

Thank you for your work on the book, it's an awesome contribution to the Erlang ecosystem. Congrats on releasing v1.0!