### PR TITLE
prevent asciidoc cross reference for binary example

### DIFF
--- a/chapters/memory.asciidoc
+++ b/chapters/memory.asciidoc
@@ -600,7 +600,7 @@ The allocator has a few interesting characteristics:
   sometimes annoyingly longer than you'd prefer.
 
 * **Sub-Binaries (Slices):**  
-  When you match binaries like `<<X:32, Rest/binary>>`, the smaller binary
+  When you match binaries like `\<<X:32, Rest/binary>>`, the smaller binary
   (`Rest`) still references the original larger binary, avoiding copying is
   great, until you realize you've accidentally kept a giant binary alive just to
   reference a tiny bit. In these cases, calling `binary:copy/1` is your friend.


### PR DESCRIPTION
Thank you for sharing your expertise, Erik!

Just noticed a small thing that effects all formats - one example was erroneously being evaluated by `asciidoc` as an internal cross reference, so it ended up trying to make that a link. A backslash did the trick to keep that from happening.

Before this change, the webpage version, for example, looked like this:
![2025-06-20T14:41:42-07:00](https://github.com/user-attachments/assets/75ece795-342f-4a88-b30f-eae48ba82778)

and after this change, it now correctly renders like this:
![2025-06-20T14:42:02-07:00](https://github.com/user-attachments/assets/b836f198-6c6f-40c5-8347-21f6ff9bd8f9)

(The reason for the color difference leading up to the example was just because I was searching for the phrase "when you match binaries like" in my browser to find the relevant section).