### PR TITLE
Use etp's name from etp-help

### DIFF
--- a/chapters/debugging.asciidoc
+++ b/chapters/debugging.asciidoc
@@ -778,10 +778,10 @@ those you own. How to reconfigure this is out of scope for this book.
 
 GDB macros can automate repetitive tasks and provide shortcuts for complex
 commands, enhancing the efficiency of your debugging sessions. The Erlang
-runtime includes a set of predefined GDB macros, known as the Erlang
-Pathologist Toolkit (ETP), which facilitate the inspection of various
-aspects of the BEAM, such as internal BEAM structures, process states,
-memory allocation, and scheduling information.
+runtime includes a set of predefined GDB macros, known as the Emulator Toolbox
+for Pathologists (ETP), which facilitate the inspection of various aspects of
+the BEAM, such as internal BEAM structures, process states, memory allocation,
+and scheduling information.
 
 The ETP macros can be found in `erts/etc/unix/etp-commands`. They are
 automatically loaded into your GDB session when you launch it via the

--- a/chapters/processes.asciidoc
+++ b/chapters/processes.asciidoc
@@ -469,7 +469,7 @@ The shell helper `c:bt(Pid)` is just a convenience wrapper around `erlang:proces
 Combined with `process_info` items such as `memory` or `reductions`,
 these queries give a view of a process’s stack, heap, and PCB-like fields.
 
-For a deeper, byte-level view the runtime ships with the **Erlang Toolkit for Pathologist (EPT)**—a collection of GDB macros (`etp-stackdump`, `etp-heapdump`, `etp-process-info`, and friends) that walk live BEAM data structures in a paused VM or core dump. 
+For a deeper, byte-level view the runtime ships with the **Emulator Toolbox for Pathologists (ETP)**—a collection of GDB macros (`etp-stackdump`, `etp-heapdump`, `etp-process-info`, and friends) that walk live BEAM data structures in a paused VM or core dump. 
 
 See xref:AP-BuildingERTS[] for more information on how to build the a debug version of the
 Erlang runtime system with ETP support. 


### PR DESCRIPTION
I found that in etp-help, the meaning for the acronym is "Emulator Toolbox for Pathologists".

https://github.com/erlang/otp/blob/30967e3dd804f8ca32ad000cc38d69e12bf7494b/erts/etc/unix/etp-commands.in#L38C3-L40