### PR TITLE
use `term_to_binary` and fix module name

### DIFF
--- a/chapters/memory.asciidoc
+++ b/chapters/memory.asciidoc
@@ -1166,7 +1166,7 @@ size() ->
  2> share:share(10,[a,b,c]), ok.
  ok
 
- 3> byte_size(list_to_binary(test:share(10,[a,b,c]))), ok.
+ 3> byte_size(term_to_binary(share:share(10,[a,b,c]))), ok.
  HUGE size (13695500364)
  Abort trap: 6
 


### PR DESCRIPTION
Using `list_to_binary` errors out as the argument is a list of tuple - 

```erlang
7> byte_size(list_to_binary(share:share(1,[a,b,c]))), ok.
** exception error: bad argument
     in function  list_to_binary/1
        called as list_to_binary([{[1,a,b,c],[1,a,b,c]},
                                  {[1,a,b,c],[1,a,b,c]},
                                  {[1,a,b,c],[1,a,b,c]}])
        *** argument 1: not an iolist term
```
