### PR TITLE
Fix typo in jump_on_val description

### DIFF
--- a/chapters/beam_loader.asciidoc
+++ b/chapters/beam_loader.asciidoc
@@ -333,7 +333,7 @@ or atoms. If the value is of any other type the compiler will not emit a
 `select_val` instruction. The loader uses a couple of heuristics to figure
 out what type algorithm to use when doing the `select_val`.
 
-jump_on_val:: Create a jump table and use the value as the index. This if very
+jump_on_val:: Create a jump table and use the value as the index. This is very
 efficient and happens when a group of close together integers are used as the
 value to select on. If not all values are present, the jump table is padded with
 extra fail label slots.


### PR DESCRIPTION
Replace `if` by `is` to fix typo.